### PR TITLE
XCode 5 refactor

### DIFF
--- a/CustomIOS7AlertView/CustomIOS7AlertView/View/CustomIOS7AlertView.h
+++ b/CustomIOS7AlertView/CustomIOS7AlertView/View/CustomIOS7AlertView.h
@@ -13,21 +13,16 @@
 
 @interface CustomIOS7AlertView : UIView
 
-@property (nonatomic, retain) UIView *parentView;    // The parent view this 'dialog' is attached to
-@property (nonatomic, retain) UIView *dialogView;    // Dialog's container view
-@property (nonatomic, retain) UIView *containerView; // Container within the dialog (place your ui elements here)
-@property (nonatomic, retain) UIView *buttonView;    // Buttons on the bottom of the dialog
-
+@property (nonatomic, strong) UIView *containerView; // Container within the dialog (place your ui elements here)
 @property (nonatomic, assign) id delegate;
-@property (nonatomic, retain) NSMutableArray *buttonTitles;
 
-- (id)initWithParentView: (UIView *)_parentView;
-- (id)initWithParentView:(UIView *)_parentView
+- (id)initWithParentView: (UIView *)parentView;
+- (id)initWithParentView:(UIView *)parentView
            motionEffects:(BOOL)motionEffects;
 
 - (void)show;
 - (void)close;
-- (void)setButtonTitles: (NSMutableArray *)buttonTitles;
+- (void)setButtonTitles:(NSArray *)buttonTitles;
 
 - (IBAction)customIOS7dialogButtonTouchUpInside:(id)sender;
 

--- a/CustomIOS7AlertView/CustomIOS7AlertView/View/CustomIOS7AlertView.m
+++ b/CustomIOS7AlertView/CustomIOS7AlertView/View/CustomIOS7AlertView.m
@@ -11,78 +11,81 @@
 
 #import "CustomIOS7AlertView.h"
 
+const static CGFloat kCustomIOS7AlertViewDefaultButtonHeight       = 50;
+const static CGFloat kCustomIOS7AlertViewDefaultButtonSpacerHeight =  1;
+const static CGFloat kCustomIOS7AlertViewCornerRadius              =  7;
+
+@interface CustomIOS7AlertView()
+
+@property (nonatomic, strong) UIView *parentView;    // The parent view this 'dialog' is attached to
+@property (nonatomic, strong) UIView *dialogView;    // Dialog's container view
+@property (nonatomic, strong) UIView *buttonView;    // Buttons on the bottom of the dialog
+
+@property (nonatomic, strong) NSArray *buttonTitles;
+
+@property (nonatomic, assign) CGFloat buttonHeight;
+@property (nonatomic, assign) CGFloat buttonSpacerHeight;
+
+@end
+
 @implementation CustomIOS7AlertView
 
-@synthesize parentView, containerView, dialogView, buttonView;
-@synthesize delegate;
-@synthesize buttonTitles;
-
-CGFloat static defaultButtonHeight = 50;
-CGFloat static defaultButtonSpacerHeight = 1;
-CGFloat static cornerRadius = 7;
-
-CGFloat buttonHeight = 0;
-CGFloat buttonSpacerHeight = 0;
-
-- (id)initWithParentView: (UIView *)_parentView
+- (id)initWithParentView:(UIView *)parentView
 {
-  return [self initWithParentView:_parentView
-                    motionEffects:YES];
+    return [self initWithParentView:parentView
+                      motionEffects:YES];
 }
 
-- (id)initWithParentView:(UIView *)_parentView
+- (id)initWithParentView:(UIView *)parentView
            motionEffects:(BOOL)motionEffects
 {
-  self = [super initWithFrame:_parentView.frame];
-
-  if (self) {
-    parentView = _parentView;
-    delegate = self;
-    buttonTitles = [NSMutableArray arrayWithObject:@"Close"];
+    self = [super initWithFrame:parentView.frame];
     
-    if (motionEffects) {
-      [self applyMotionEffect];
+    if (self) {
+        self.parentView = parentView;
+        self.delegate = self;
+        self.buttonTitles = @[@"Close"];
+        
+        if (motionEffects) {
+            [self applyMotionEffect];
+        }
     }
-  }
-  return self;
+    return self;
 }
 
 // Create the dialog view, and animate opening the dialog
 - (void)show
 {
-    dialogView = [self createContainerView];
-
-    dialogView.layer.opacity = 0.5f;
-    dialogView.layer.transform = CATransform3DMakeScale(1.3f, 1.3f, 1.0);
-
+    self.dialogView = [self createContainerView];
+    
+    self.dialogView.layer.opacity = 0.5f;
+    self.dialogView.layer.transform = CATransform3DMakeScale(1.3f, 1.3f, 1.0);
+    
     self.backgroundColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:0];
-
-    [self addSubview:dialogView];
-    [parentView addSubview:self];
-
+    
+    [self addSubview:self.dialogView];
+    [self.parentView addSubview:self];
+    
     [UIView animateWithDuration:0.2f delay:0.0 options:UIViewAnimationOptionCurveEaseInOut
-					 animations:^{
-						 self.backgroundColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:0.4f];
-                         dialogView.layer.opacity = 1.0f;
-                         dialogView.layer.transform = CATransform3DMakeScale(1, 1, 1);
-					 }
-					 completion:NULL
+                     animations:^{
+                         self.backgroundColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:0.4f];
+                         self.dialogView.layer.opacity = 1.0f;
+                         self.dialogView.layer.transform = CATransform3DMakeScale(1, 1, 1);
+                     }
+                     completion:NULL
      ];
-}
-
-- (void)setDelegate: (id)_delegate
-{
-    delegate = _delegate;
 }
 
 // Button has touched
 - (IBAction)customIOS7dialogButtonTouchUpInside:(id)sender
 {
-    [delegate customIOS7dialogButtonTouchUpInside:self clickedButtonAtIndex:[sender tag]];
+    [self.delegate customIOS7dialogButtonTouchUpInside:self
+                                  clickedButtonAtIndex:[sender tag]];
 }
 
 // Default button behaviour
-- (void)customIOS7dialogButtonTouchUpInside: (CustomIOS7AlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
+- (void)customIOS7dialogButtonTouchUpInside:(CustomIOS7AlertView *)alertView
+                       clickedButtonAtIndex:(NSInteger)buttonIndex
 {
     NSLog(@"Button Clicked! %d, %d", buttonIndex, [alertView tag]);
     [self close];
@@ -91,64 +94,64 @@ CGFloat buttonSpacerHeight = 0;
 // Dialog close animation then cleaning and removing the view from the parent
 - (void)close
 {
-    dialogView.layer.transform = CATransform3DMakeScale(1, 1, 1);
-    dialogView.layer.opacity = 1.0f;
-
+    self.dialogView.layer.transform = CATransform3DMakeScale(1, 1, 1);
+    self.dialogView.layer.opacity = 1.0f;
+    
     [UIView animateWithDuration:0.2f delay:0.0 options:UIViewAnimationOptionTransitionNone
-					 animations:^{
-						 self.backgroundColor = [UIColor colorWithRed:0.0f green:0.0f blue:0.0f alpha:0.0f];
-                         dialogView.layer.transform = CATransform3DMakeScale(0.6f, 0.6f, 1.0);
-                         dialogView.layer.opacity = 0.0f;
-					 }
-					 completion:^(BOOL finished) {
+                     animations:^{
+                         self.backgroundColor = [UIColor colorWithRed:0.0f green:0.0f blue:0.0f alpha:0.0f];
+                         self.dialogView.layer.transform = CATransform3DMakeScale(0.6f, 0.6f, 1.0);
+                         self.dialogView.layer.opacity = 0.0f;
+                     }
+                     completion:^(BOOL finished) {
                          for (UIView *v in [self subviews]) {
                              [v removeFromSuperview];
                          }
                          [self removeFromSuperview];
-					 }
+                     }
 	 ];
 }
 
 - (void)setSubView: (UIView *)subView
 {
-    containerView = subView;
+    self.containerView = subView;
 }
 
 // Creates the container view here: create the dialog, then add the custom content and buttons
 - (UIView *)createContainerView
 {
-    if ([buttonTitles count] > 0) {
-        buttonHeight = defaultButtonHeight;
-        buttonSpacerHeight = defaultButtonSpacerHeight;
+    if ([self.buttonTitles count] > 0) {
+        self.buttonHeight       = kCustomIOS7AlertViewDefaultButtonHeight;
+        self.buttonSpacerHeight = kCustomIOS7AlertViewDefaultButtonSpacerHeight;
     } else {
-        buttonHeight = 0;
-        buttonSpacerHeight = 0;
+        self.buttonHeight = 0;
+        self.buttonSpacerHeight = 0;
     }
-
-    if (containerView == NULL) {
-        containerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 300, 150)];
+    
+    if (self.containerView == NULL) {
+        self.containerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 300, 150)];
     }
-
-    CGFloat dialogWidth = containerView.frame.size.width;
-    CGFloat dialogHeight = containerView.frame.size.height + buttonHeight + buttonSpacerHeight;
-
-    CGFloat screenWidth = [UIScreen mainScreen].bounds.size.width;
+    
+    CGFloat dialogWidth  = self.containerView.frame.size.width;
+    CGFloat dialogHeight = self.containerView.frame.size.height + self.buttonHeight + self.buttonSpacerHeight;
+    
+    CGFloat screenWidth  = [UIScreen mainScreen].bounds.size.width;
     CGFloat screenHeight = [UIScreen mainScreen].bounds.size.height;
-
+    
     UIDeviceOrientation deviceOrientation = [[UIDevice currentDevice] orientation];
     if (UIDeviceOrientationIsLandscape(deviceOrientation)) {
         CGFloat tmp = screenWidth;
         screenWidth = screenHeight;
         screenHeight = tmp;
     }
-
+    
     // For the black background
     [self setFrame:CGRectMake(0, 0, screenWidth, screenHeight)];
-
+    
     // This is the dialog's container; we attach the custom content and the buttons to this one
     UIView *dialogContainer = [[UIView alloc] initWithFrame:CGRectMake((screenWidth - dialogWidth) / 2, (screenHeight - dialogHeight) / 2, dialogWidth, dialogHeight)];
-
-
+    
+    
     // First, we style the dialog to match the iOS7 UIAlertView >>>
     CAGradientLayer *gradient = [CAGradientLayer layer];
     gradient.frame = dialogContainer.bounds;
@@ -157,9 +160,11 @@ CGFloat buttonSpacerHeight = 0;
                        (id)[[UIColor colorWithRed:233.0/255.0 green:233.0/255.0 blue:233.0/255.0 alpha:1.0f] CGColor],
                        (id)[[UIColor colorWithRed:218.0/255.0 green:218.0/255.0 blue:218.0/255.0 alpha:1.0f] CGColor],
                        nil];
+
+    CGFloat cornerRadius = kCustomIOS7AlertViewCornerRadius;
     gradient.cornerRadius = cornerRadius;
     [dialogContainer.layer insertSublayer:gradient atIndex:0];
-
+    
     dialogContainer.layer.cornerRadius = cornerRadius;
     dialogContainer.layer.borderColor = [[UIColor colorWithRed:198.0/255.0 green:198.0/255.0 blue:198.0/255.0 alpha:1.0f] CGColor];
     dialogContainer.layer.borderWidth = 1;
@@ -167,15 +172,16 @@ CGFloat buttonSpacerHeight = 0;
     dialogContainer.layer.shadowOpacity = 0.1f;
     dialogContainer.layer.shadowOffset = CGSizeMake(0 - (cornerRadius+5)/2, 0 - (cornerRadius+5)/2);
     // ^^^
-
+    
     // There is a line above the button
-    UIView *lineView = [[UIView alloc] initWithFrame:CGRectMake(0, dialogContainer.bounds.size.height - buttonHeight - buttonSpacerHeight, dialogContainer.bounds.size.width, buttonSpacerHeight)];
+    UIView *lineView = [[UIView alloc] initWithFrame:CGRectMake(0, dialogContainer.bounds.size.height - self.buttonHeight - self.buttonSpacerHeight,
+                                                                dialogContainer.bounds.size.width, self.buttonSpacerHeight)];
     lineView.backgroundColor = [UIColor colorWithRed:198.0/255.0 green:198.0/255.0 blue:198.0/255.0 alpha:1.0f];
     [dialogContainer addSubview:lineView];
     // ^^^
 
     // Add the custom container if there is any
-    [dialogContainer addSubview:containerView];
+    [dialogContainer addSubview:self.containerView];
 
     // Add the buttons too
     [self addButtonsToView:dialogContainer];
@@ -185,22 +191,22 @@ CGFloat buttonSpacerHeight = 0;
 
 - (void)addButtonsToView: (UIView *)container
 {
-    CGFloat buttonWidth = container.bounds.size.width / [buttonTitles count];
+    CGFloat buttonWidth = container.bounds.size.width / [self.buttonTitles count];
 
-    for (int i=0; i<[buttonTitles count]; i++) {
+    for (int i=0; i<[self.buttonTitles count]; i++) {
 
         UIButton *closeButton = [UIButton buttonWithType:UIButtonTypeCustom];
 
-        [closeButton setFrame:CGRectMake(i * buttonWidth, container.bounds.size.height - buttonHeight, buttonWidth, buttonHeight)];
+        [closeButton setFrame:CGRectMake(i * buttonWidth, container.bounds.size.height - self.buttonHeight, buttonWidth, self.buttonHeight)];
 
         [closeButton addTarget:self action:@selector(customIOS7dialogButtonTouchUpInside:) forControlEvents:UIControlEventTouchUpInside];
         [closeButton setTag:i];
 
-        [closeButton setTitle:[buttonTitles objectAtIndex:i] forState:UIControlStateNormal];
+        [closeButton setTitle:[self.buttonTitles objectAtIndex:i] forState:UIControlStateNormal];
         [closeButton setTitleColor:[UIColor colorWithRed:0.0f green:0.5f blue:1.0f alpha:1.0f] forState:UIControlStateNormal];
         [closeButton setTitleColor:[UIColor colorWithRed:0.2f green:0.2f blue:0.2f alpha:0.5f] forState:UIControlStateHighlighted];
         [closeButton.titleLabel setFont:[UIFont boldSystemFontOfSize:14.0f]];
-        [closeButton.layer setCornerRadius:cornerRadius];
+        [closeButton.layer setCornerRadius:kCustomIOS7AlertViewCornerRadius];
 
         [container addSubview:closeButton];
     }
@@ -208,20 +214,20 @@ CGFloat buttonSpacerHeight = 0;
 
 // Add motion effects
 - (void)applyMotionEffect {
-  UIInterpolatingMotionEffect *horizontalEffect = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.x"
-                                                                                                  type:UIInterpolatingMotionEffectTypeTiltAlongHorizontalAxis];
-  horizontalEffect.minimumRelativeValue = @(-10.);
-  horizontalEffect.maximumRelativeValue = @( 10.);
-  
-  UIInterpolatingMotionEffect *verticalEffect = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.y"
-                                                                                                type:UIInterpolatingMotionEffectTypeTiltAlongVerticalAxis];
-  verticalEffect.minimumRelativeValue = @(-10.);
-  verticalEffect.maximumRelativeValue = @( 10.);
-  
-  UIMotionEffectGroup *motionEffectGroup = [[UIMotionEffectGroup alloc] init];
-  motionEffectGroup.motionEffects = @[horizontalEffect, verticalEffect];
-  
-  [self addMotionEffect:motionEffectGroup];
+    UIInterpolatingMotionEffect *horizontalEffect = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.x"
+                                                                                                    type:UIInterpolatingMotionEffectTypeTiltAlongHorizontalAxis];
+    horizontalEffect.minimumRelativeValue = @(-10.);
+    horizontalEffect.maximumRelativeValue = @( 10.);
+    
+    UIInterpolatingMotionEffect *verticalEffect = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.y"
+                                                                                                  type:UIInterpolatingMotionEffectTypeTiltAlongVerticalAxis];
+    verticalEffect.minimumRelativeValue = @(-10.);
+    verticalEffect.maximumRelativeValue = @( 10.);
+    
+    UIMotionEffectGroup *motionEffectGroup = [[UIMotionEffectGroup alloc] init];
+    motionEffectGroup.motionEffects = @[horizontalEffect, verticalEffect];
+    
+    [self addMotionEffect:motionEffectGroup];
 }
 
 @end


### PR DESCRIPTION
Since this is an iOS 7 widget, you can assume developer use will be in XCode 5 or later. Did some general code cleanup and refactoring with that in mind.

Overview:
- moved private ivars into internal interface
- removed delegate setter that was performing behavior that is already the default
- changed properties to _strong_ rather than _retain_ since compile with ARC
- made class wide constants conform to Objective-C stytle
- moved dangling buttonHeight and buttonSpacerHeight to ivars
- removed underscored ivar access in favor of explicit self referencing
- changed all ivar referencing explicit to self
- changed butonTitles to NSArray from NSMutableArray since mutability not required (or desired)

Note this pull request is on top of the motion effects pull request
