### PR TITLE
Add dialog motion effects for iOS 7

### DIFF
--- a/CustomIOS7AlertView/CustomIOS7AlertView/View/CustomIOS7AlertView.h
+++ b/CustomIOS7AlertView/CustomIOS7AlertView/View/CustomIOS7AlertView.h
@@ -20,8 +20,12 @@
 
 @property (nonatomic, assign) id delegate;
 @property (nonatomic, retain) NSMutableArray *buttonTitles;
+@property (nonatomic, assign) BOOL useMotionEffects;
 
 - (id)initWithParentView: (UIView *)_parentView;
+- (id)initWithParentView:(UIView *)_parentView
+        useMotionEffects:(BOOL)useMotionEffects;
+
 - (void)show;
 - (void)close;
 - (void)setButtonTitles: (NSMutableArray *)buttonTitles;

--- a/CustomIOS7AlertView/CustomIOS7AlertView/View/CustomIOS7AlertView.m
+++ b/CustomIOS7AlertView/CustomIOS7AlertView/View/CustomIOS7AlertView.m
@@ -16,6 +16,7 @@
 @synthesize parentView, containerView, dialogView, buttonView;
 @synthesize delegate;
 @synthesize buttonTitles;
+@synthesize useMotionEffects;
 
 CGFloat static defaultButtonHeight = 50;
 CGFloat static defaultButtonSpacerHeight = 1;
@@ -26,11 +27,20 @@ CGFloat buttonSpacerHeight = 0;
 
 - (id)initWithParentView: (UIView *)_parentView
 {
+    return [self initWithParentView:_parentView
+                   useMotionEffects:YES];
+}
+
+- (id)initWithParentView:(UIView *)_parentView
+        useMotionEffects:(BOOL)_useMotionEffects
+{
     self = [super initWithFrame:_parentView.frame];
+    
     if (self) {
         parentView = _parentView;
         delegate = self;
         buttonTitles = [NSMutableArray arrayWithObject:@"Close"];
+        useMotionEffects = _useMotionEffects;
     }
     return self;
 }
@@ -40,6 +50,9 @@ CGFloat buttonSpacerHeight = 0;
 {
     dialogView = [self createContainerView];
 
+    if (useMotionEffects)
+        [self applyMotionEffects];
+    
     dialogView.layer.opacity = 0.5f;
     dialogView.layer.transform = CATransform3DMakeScale(1.3f, 1.3f, 1.0);
 
@@ -192,7 +205,29 @@ CGFloat buttonSpacerHeight = 0;
 
         [container addSubview:closeButton];
     }
+}
 
+// Add motion effects
+- (void)applyMotionEffects {
+    if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1)
+        return;
+    
+    static const CGFloat effectExtent = 10.;
+    
+    UIInterpolatingMotionEffect *horizontalEffect = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.x"
+                                                                                                    type:UIInterpolatingMotionEffectTypeTiltAlongHorizontalAxis];
+  horizontalEffect.minimumRelativeValue = @(-effectExtent);
+  horizontalEffect.maximumRelativeValue = @( effectExtent);
+  
+  UIInterpolatingMotionEffect *verticalEffect = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.y"
+                                                                                                type:UIInterpolatingMotionEffectTypeTiltAlongVerticalAxis];
+  verticalEffect.minimumRelativeValue = @(-effectExtent);
+  verticalEffect.maximumRelativeValue = @( effectExtent);
+  
+  UIMotionEffectGroup *motionEffectGroup = [[UIMotionEffectGroup alloc] init];
+  motionEffectGroup.motionEffects = @[horizontalEffect, verticalEffect];
+  
+  [dialogView addMotionEffect:motionEffectGroup];
 }
 
 @end


### PR DESCRIPTION
As previous, adding motion effects for iOS 7. But no longer assume iOS 7.

Fixes:
- Use motion effect only if iOS 7.
- Apply motion effects to the dialog view, not the full screen view being used for "modal" purposes.

Note this is a fresh, new branch directly off your master. Same name as previous, but it is a new branch. I chose not to apply the "fix" to the two issues you raised on that previous branch since I had made refactoring changes on my other branch and rebasing would have been more difficult that this route (a new branch with the same name). I can, of course, only get away with this slight of hand since no one but me had pulled either of my two branches.
