### PR TITLE
Custom Button Styles

### DIFF
--- a/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.h
+++ b/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.h
@@ -25,6 +25,7 @@
 
 @property (nonatomic, assign) id<CustomIOSAlertViewDelegate> delegate;
 @property (nonatomic, retain) NSArray *buttonTitles;
+@property (nonatomic, retain) NSDictionary *buttonStyles;
 @property (nonatomic, assign) BOOL useMotionEffects;
 
 @property (copy) void (^onButtonTouchUpInside)(CustomIOSAlertView *alertView, int buttonIndex) ;

--- a/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.m
+++ b/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.m
@@ -206,17 +206,25 @@ CGFloat buttonSpacerHeight = 0;
     UIView *dialogContainer = [[UIView alloc] initWithFrame:CGRectMake((screenSize.width - dialogSize.width) / 2, (screenSize.height - dialogSize.height) / 2, dialogSize.width, dialogSize.height)];
 
     // First, we style the dialog to match the iOS7 UIAlertView >>>
-    CAGradientLayer *gradient = [CAGradientLayer layer];
-    gradient.frame = dialogContainer.bounds;
-    gradient.colors = [NSArray arrayWithObjects:
-                       (id)[[UIColor colorWithRed:218.0/255.0 green:218.0/255.0 blue:218.0/255.0 alpha:1.0f] CGColor],
-                       (id)[[UIColor colorWithRed:233.0/255.0 green:233.0/255.0 blue:233.0/255.0 alpha:1.0f] CGColor],
-                       (id)[[UIColor colorWithRed:218.0/255.0 green:218.0/255.0 blue:218.0/255.0 alpha:1.0f] CGColor],
-                       nil];
-
+    //BUddyHopp customization
+    CALayer *layer = [CALayer layer];
+    layer.frame = dialogContainer.bounds;
     CGFloat cornerRadius = kCustomIOSAlertViewCornerRadius;
-    gradient.cornerRadius = cornerRadius;
-    [dialogContainer.layer insertSublayer:gradient atIndex:0];
+    layer.cornerRadius = cornerRadius;
+    [dialogContainer.layer insertSublayer:layer atIndex:0];
+    
+    
+//    CAGradientLayer *gradient = [CAGradientLayer layer];
+//    gradient.frame = dialogContainer.bounds;
+//    gradient.colors = [NSArray arrayWithObjects:
+//                       (id)[[UIColor colorWithRed:218.0/255.0 green:218.0/255.0 blue:218.0/255.0 alpha:1.0f] CGColor],
+//                       (id)[[UIColor colorWithRed:233.0/255.0 green:233.0/255.0 blue:233.0/255.0 alpha:1.0f] CGColor],
+//                       (id)[[UIColor colorWithRed:218.0/255.0 green:218.0/255.0 blue:218.0/255.0 alpha:1.0f] CGColor],
+//                       nil];
+//
+//    CGFloat cornerRadius = kCustomIOSAlertViewCornerRadius;
+//    gradient.cornerRadius = cornerRadius;
+//    [dialogContainer.layer insertSublayer:gradient atIndex:0];
 
     dialogContainer.layer.cornerRadius = cornerRadius;
     dialogContainer.layer.borderColor = [[UIColor colorWithRed:198.0/255.0 green:198.0/255.0 blue:198.0/255.0 alpha:1.0f] CGColor];

--- a/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.m
+++ b/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.m
@@ -209,6 +209,7 @@ CGFloat buttonSpacerHeight = 0;
     //BUddyHopp customization
     CALayer *layer = [CALayer layer];
     layer.frame = dialogContainer.bounds;
+    layer.backgroundColor = [UIColor whiteColor].CGColor;
     CGFloat cornerRadius = kCustomIOSAlertViewCornerRadius;
     layer.cornerRadius = cornerRadius;
     [dialogContainer.layer insertSublayer:layer atIndex:0];

--- a/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.m
+++ b/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.m
@@ -12,9 +12,9 @@
 #import "CustomIOSAlertView.h"
 #import <QuartzCore/QuartzCore.h>
 
-const static CGFloat kCustomIOSAlertViewDefaultButtonHeight       = 50;
+const static CGFloat kCustomIOSAlertViewDefaultButtonHeight       = 44;
 const static CGFloat kCustomIOSAlertViewDefaultButtonSpacerHeight = 1;
-const static CGFloat kCustomIOSAlertViewCornerRadius              = 7;
+const static CGFloat kCustomIOSAlertViewCornerRadius              = 6;
 const static CGFloat kCustomIOS7MotionEffectExtent                = 10.0;
 
 @implementation CustomIOSAlertView
@@ -259,9 +259,9 @@ CGFloat buttonSpacerHeight = 0;
         [closeButton setTag:i];
 
         [closeButton setTitle:[buttonTitles objectAtIndex:i] forState:UIControlStateNormal];
-        [closeButton setTitleColor:[UIColor colorWithRed:0.0f green:0.5f blue:1.0f alpha:1.0f] forState:UIControlStateNormal];
+        [closeButton setTitleColor:[UIColor colorWithRed:3.0f/255.0f green:122.0f/255.0f blue:1.0f alpha:1.0f] forState:UIControlStateNormal];
         [closeButton setTitleColor:[UIColor colorWithRed:0.2f green:0.2f blue:0.2f alpha:0.5f] forState:UIControlStateHighlighted];
-        [closeButton.titleLabel setFont:[UIFont boldSystemFontOfSize:14.0f]];
+        [closeButton.titleLabel setFont:[UIFont boldSystemFontOfSize:17.0f]];
         [closeButton.layer setCornerRadius:kCustomIOSAlertViewCornerRadius];
 
         [container addSubview:closeButton];

--- a/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.m
+++ b/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.m
@@ -25,6 +25,7 @@ CGFloat buttonSpacerHeight = 0;
 @synthesize parentView, containerView, dialogView, onButtonTouchUpInside;
 @synthesize delegate;
 @synthesize buttonTitles;
+@synthesize buttonStyles;
 @synthesize useMotionEffects;
 
 - (id)initWithParentView: (UIView *)_parentView
@@ -266,12 +267,37 @@ CGFloat buttonSpacerHeight = 0;
 
         [closeButton addTarget:self action:@selector(customIOS7dialogButtonTouchUpInside:) forControlEvents:UIControlEventTouchUpInside];
         [closeButton setTag:i];
-
+        
         [closeButton setTitle:[buttonTitles objectAtIndex:i] forState:UIControlStateNormal];
-        [closeButton setTitleColor:[UIColor colorWithRed:3.0f/255.0f green:122.0f/255.0f blue:1.0f alpha:1.0f] forState:UIControlStateNormal];
-        [closeButton setTitleColor:[UIColor colorWithRed:0.2f green:0.2f blue:0.2f alpha:0.5f] forState:UIControlStateHighlighted];
-        [closeButton.titleLabel setFont:[UIFont boldSystemFontOfSize:17.0f]];
         [closeButton.layer setCornerRadius:kCustomIOSAlertViewCornerRadius];
+        
+        UIColor *normalTitleColor;
+        UIColor *highlightedTitleColor;
+        UIFont *font;
+        
+        NSNumber *style = [buttonStyles objectForKey: [NSNumber numberWithInt: i]];
+        
+        switch ([style intValue]) {
+            case UIAlertActionStyleDefault:
+                normalTitleColor = [UIColor colorWithRed:3.0f/255.0f green:122.0f/255.0f blue:1.0f alpha:1.0f];
+                highlightedTitleColor = [UIColor colorWithRed:0.2f green:0.2f blue:0.2f alpha:0.5f];
+                font = [UIFont boldSystemFontOfSize:17.0f];
+                break;
+            case UIAlertActionStyleCancel:
+                normalTitleColor = [UIColor colorWithRed:3.0f/255.0f green:122.0f/255.0f blue:1.0f alpha:1.0f];
+                highlightedTitleColor = [UIColor colorWithRed:0.2f green:0.2f blue:0.2f alpha:0.5f];
+                font = [UIFont systemFontOfSize:17.0f];
+                break;
+            case UIAlertActionStyleDestructive:
+                normalTitleColor = [UIColor colorWithRed:255.0f/255.0f green:0.0f blue:0.0f alpha:1.0f];
+                highlightedTitleColor = [UIColor colorWithRed:0.2f green:0.2f blue:0.2f alpha:0.5f];
+                font = [UIFont systemFontOfSize:17.0f];
+                break;
+        }
+        
+        [closeButton setTitleColor:normalTitleColor forState:UIControlStateNormal];
+        [closeButton setTitleColor:highlightedTitleColor forState:UIControlStateHighlighted];
+        [closeButton.titleLabel setFont:font];
 
         [container addSubview:closeButton];
     }

--- a/CustomIOSAlertView/CustomIOSAlertView/ViewController.m
+++ b/CustomIOSAlertView/CustomIOSAlertView/ViewController.m
@@ -45,7 +45,12 @@
     [alertView setContainerView:[self createDemoView]];
 
     // Modify the parameters
-    [alertView setButtonTitles:[NSMutableArray arrayWithObjects:@"Close1", @"Close2", @"Close3", nil]];
+    [alertView setButtonTitles:[NSMutableArray arrayWithObjects:@"Default", @"Cancel", @"Destructive", nil]];
+    [alertView setButtonStyles: @{
+                                  [NSNumber numberWithInt: 0] : [NSNumber numberWithInt:UIAlertActionStyleDefault],
+                                  [NSNumber numberWithInt: 1] : [NSNumber numberWithInt:UIAlertActionStyleCancel],
+                                  [NSNumber numberWithInt: 2] : [NSNumber numberWithInt:UIAlertActionStyleDestructive],
+                                  }];
     [alertView setDelegate:self];
     
     // You may use a Block, rather than a delegate.


### PR DESCRIPTION
In order to keep it simple for now (and since we don't need more), I simply added the possibility of specifying for each button a UIAlertActionStyle value, which is then used by the alert to render the button according to iOS native alerts. 

If none is specified it takes the default value, which is the bold one.