### PR TITLE
Allow multi-line text for buttons

### DIFF
--- a/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.m
+++ b/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.m
@@ -262,6 +262,8 @@ CGFloat buttonSpacerHeight = 0;
         [closeButton setTitleColor:[UIColor colorWithRed:0.0f green:0.5f blue:1.0f alpha:1.0f] forState:UIControlStateNormal];
         [closeButton setTitleColor:[UIColor colorWithRed:0.2f green:0.2f blue:0.2f alpha:0.5f] forState:UIControlStateHighlighted];
         [closeButton.titleLabel setFont:[UIFont boldSystemFontOfSize:14.0f]];
+        closeButton.titleLabel.numberOfLines = 0;
+        closeButton.titleLabel.textAlignment = NSTextAlignmentCenter;
         [closeButton.layer setCornerRadius:kCustomIOSAlertViewCornerRadius];
 
         [container addSubview:closeButton];


### PR DESCRIPTION
Currently, the buttons only display text in one line, which results in truncation if the text is long.

This fix should allow longer button texts to be formatted better.