### PR TITLE
Added an extra functionality:(BOOL) closeOnTouchUpOutside

### DIFF
--- a/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.h
+++ b/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.h
@@ -26,6 +26,7 @@
 @property (nonatomic, assign) id<CustomIOSAlertViewDelegate> delegate;
 @property (nonatomic, retain) NSArray *buttonTitles;
 @property (nonatomic, assign) BOOL useMotionEffects;
+@property (nonatomic, assign) BOOL closeOnTouchUpOutside;       // Closes the AlertView when finger is lifted outside the bounds.
 
 @property (copy) void (^onButtonTouchUpInside)(CustomIOSAlertView *alertView, int buttonIndex) ;
 

--- a/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.m
+++ b/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.m
@@ -26,6 +26,7 @@ CGFloat buttonSpacerHeight = 0;
 @synthesize delegate;
 @synthesize buttonTitles;
 @synthesize useMotionEffects;
+@synthesize closeOnTouchUpOutside;
 
 - (id)initWithParentView: (UIView *)_parentView
 {
@@ -45,6 +46,7 @@ CGFloat buttonSpacerHeight = 0;
 
         delegate = self;
         useMotionEffects = false;
+        closeOnTouchUpOutside = false;
         buttonTitles = @[@"Close"];
         
         [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
@@ -443,6 +445,17 @@ CGFloat buttonSpacerHeight = 0;
 					 }
 					 completion:nil
 	 ];
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    if (!closeOnTouchUpOutside) {
+        return;
+    }
+    
+    UITouch *touch = [touches anyObject];
+    if ([touch.view isKindOfClass:[CustomIOSAlertView class]]) {
+        [self close];
+    }
 }
 
 @end


### PR DESCRIPTION
## Additional Function: Close AlertView when touched outside the bounds.

 I wanted to use a function to close the alertview whenever I touch outside the view so that I wouldn't need to have a button. This is just an additional function that I thought might be useful. 

![gif](https://cloud.githubusercontent.com/assets/12219300/18302420/aa85c1e8-748c-11e6-8b96-884364f41280.gif)
### Changes
- Old codes are not changed, only a few lines are added.
- Behavior of CustomIOSAlertview on init is the same.
- Use `[customAlertView setCloseOnTouchUpOutside:YES];` to set this functionality.
- Default is NO.
