### PR TITLE
Do not assume the first found window in [[UIApplication sharedApplication] windows] to be the right one

### DIFF
--- a/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.m
+++ b/CustomIOSAlertView/CustomIOSAlertView/View/CustomIOSAlertView.m
@@ -121,7 +121,14 @@ CGFloat buttonSpacerHeight = 0;
 
         }
 
-        [[[[UIApplication sharedApplication] windows] firstObject] addSubview:self];
+        UIWindow *window;
+        for (id subwindow in [[UIApplication sharedApplication] windows]) {
+            if ([subwindow isMemberOfClass:[UIWindow class]]) {
+                window = subwindow;
+                break;
+            }
+        }
+        [window addSubview:self];
     }
 
     dialogView.layer.opacity = 0.5f;


### PR DESCRIPTION

Before showing the alert view it is added on the first object found in [[UIApplication sharedApplication] windows].
Starting with iOS 9 Apple introduced a feature called Picture in Picture; when this feature is enabled
the first found window will be an object of type `PGHostedWindow` which holds the popup view of the PiP feature (note that thiss happens only on iPads).
Trying to add the alert view on that window will make the alert view to not appear at all. This pull request fixes that by looking on the first object in [[UIApplication sharedApplication] windows] which is _exactly_ a type of `UIWindow` class.